### PR TITLE
Add conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: tre-example-challenge
 channels:
-  - conda-forge
+  - defaults
 dependencies:
   - faker
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: tre-example-challenge
-channels:
-  - defaults
+# channels:
+#   - defaults
 dependencies:
   - faker
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: tre-example-challenge
+channels:
+  - conda-forge
+dependencies:
+  - faker
+  - numpy
+  - pandas
+  - typer


### PR DESCRIPTION
This is useful when installing in a restricted environment where PyPI is blocked, but some Conda channels are available.